### PR TITLE
Fix table sort defer faplotlength

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -81,7 +81,7 @@
 </div>
 
 <!-- JS Libraries -->
-<script type="text/javascript" src="//d3js.org/queue.v1.min.js"></script>
+<script type="text/javascript" src="//d3js.org/d3-queue.v2.min.js"></script>
 <script type="text/javascript" src="js/stats.min.js"></script>
 <script type="text/javascript" src="js/three.min.js"></script>
 <script type="text/javascript" src="//d3js.org/d3.v3.min.js"></script>

--- a/client/js/sortable-table.js
+++ b/client/js/sortable-table.js
@@ -17,9 +17,9 @@ var headerGrp;
 var rowsGrp;
 var tableControlBox;
 
-queue()
-	.defer(d3.json, "data/subjects.json")
-	.await(buildTable);
+var subjectQ = d3_queue.queue();
+subjectQ.defer(d3.json, "data/subjects.json");
+subjectQ.await(buildTable);
 
 function buildTable(error, data) {
 	data.forEach(function (d) {

--- a/client/js/tract-details.js
+++ b/client/js/tract-details.js
@@ -18,9 +18,15 @@ var t = d3.transition()
 var tracts;
 var faPlotLength;
 
-queue()
-    .defer(d3.csv, "data/nodes.csv")
-    .await(buildTractCheckboxes);
+var nodeQ = d3_queue.queue();
+nodeQ.defer(d3.csv, "data/nodes.csv");
+nodeQ.await(buildFromNodes);
+
+function buildFromNodes(error, data) {
+	buildTractCheckboxes(error, data);
+	buildPlotGui(error, data);
+	ready(error, data);
+}
 
 function buildTractCheckboxes(error, data) {
     if (error) throw error;
@@ -136,9 +142,9 @@ var plotsControlBox = new plotsGuiConfigObj();
 var plotsGuiContainer = document.getElementById('plots-gui-container');
 plotsGuiContainer.appendChild(plotsGui.domElement);
 
-queue()
-    .defer(d3.csv, "data/nodes.csv")
-    .await(buildPlotGui);
+// queue()
+//     .defer(d3.csv, "data/nodes.csv")
+//     .await(buildPlotGui);
 
 function buildPlotGui(error, data) {
     if (error) throw error;
@@ -162,10 +168,9 @@ function buildPlotGui(error, data) {
 }
 plotsGui.close();
 
-// FIGURE OUT QUEUE TO MAKE SURE METADATA TABLE LOADS FIRST
-queue()
-    .defer(d3.csv, "data/nodes.csv")
-    .await(ready);
+// queue()
+//     .defer(d3.csv, "data/nodes.csv")
+//     .await(ready);
 
 function ready(error, data) {
     if (error) throw error;


### PR DESCRIPTION
This fixes an async issue with the variable faPlotLength, which is used in 3d-brain.js but defined in tract-details.js.

- I added a queue to defer the threejs init function until faPlotLength is defined.
- While doing so, I updated the d3.queue version that we have in index.html and the corresponding queue calls in sortable-table.js and tract-details.js.
- Lastly, I combined the queue calls in tract-details.js so that we don't read nodes.csv three times.